### PR TITLE
Set PRNG value for each thread

### DIFF
--- a/start.c
+++ b/start.c
@@ -38,7 +38,6 @@ int main() {
 	int workerCount = getConfigInt("select") || getConfigInt("randomise") ? getConfigInt("workerCount") : 1;
 	local_ver = getConfigStr("Version");
 	init_level_cfg();
-	srand(time(0)); // Seed the RNG for the select config option
 	curl_global_init(CURL_GLOBAL_DEFAULT);	// Initialize libcurl
 	int update = checkForUpdates(local_ver);
 	
@@ -72,6 +71,9 @@ int main() {
 	#pragma omp parallel
 	{
 		int ID = omp_get_thread_num();
+		
+		// Seed each thread's PRNG for the select and randomise config options
+		srand(((int)time(NULL)) ^ ID);
 		
 		while (1) {
 			struct Result result = calculateOrder(ID);


### PR DESCRIPTION
OpenMP requires srand to be done for each thread, or the results will not be random.

You can see on master just by quickly running a few times that the first few roadmaps found are the same.