### PR TITLE
Added macOS build instructions + Make formula.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,17 @@
-CC=gcc
 CFLAGS=-lcurl -lconfig -fopenmp -Wall -O2
 TARGET=recipesAtHome
 DEPS=start.h inventory.h recipes.h config.h FTPManagement.h cJSON.h calculator.h logger.h
 OBJ=start.o inventory.o recipes.o config.o FTPManagement.o cJSON.o calculator.o logger.o
+
+UNAME:=$(shell uname)
+ifeq ($(UNAME), Linux)
+	CC=gcc
+endif
+ifeq ($(UNAME), Darwin)
+	MACPREFIX:=$(shell brew --prefix)
+	CC:=$(MACPREFIX)/opt/llvm/bin/clang
+	CFLAGS:=-I$(MACPREFIX)/include -L$(MACPREFIX)/lib $(CFLAGS)
+endif
 
 default: $(TARGET)
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,15 @@ Should there be any problems in this building process, please let us know by pos
 ### Windows
 To build on Windows, use the Visual Studio CipesAtHome.sln solution file. You will need to install libcurl and libconfig. This can be done by making use of vcpkg.
 
-### Mac
-TODO
+### macOS
+To build on macOS (w/ Homebrew installed), you will need to run the following commands from the project root, in order to run this program:
+1. `brew install llvm libomp libconfig`
+1. `make`
+1. `./recipesAtHome`
+*Notes:* The `clang` included w/ macOS will not work (it's compiled w/o OpenMP).
+MacPorts should work by replacing the prefix in the makefile (e.g. to `PREFIX:=/opt`), etc.
+
+Should there be any problems in this building process, please let us know by posting an issue on Github.
 
 ## Config Settings
 Below are a set of config parameters which can be changed by the user. These will affect how the algorithm handles legal moves, as well as check for the current program version on Github.


### PR DESCRIPTION
I modified the Makefile to get a working build on macOS conditionally (leaving the Linux instructions essentially unchanged) using Homebrew as a package manager. These are minimal changes, so it looks a bit hacky, but should be fine – separating out the various C flags by their use (compiler, linker, preprocessor) would alleviate that if it's up for consideration.

I've also added appropriate build instructions (with hints for other setups) to the README.