### PR TITLE
Very Ugly (but fast) Loop Unrolling Speedup in StatusOk

### DIFF
--- a/inventory.h
+++ b/inventory.h
@@ -244,7 +244,7 @@ struct Recipe {
 // Recipe functions
 int getIndexOfRecipe(enum Type_Sort item);
 struct Recipe* getRecipeList();
-int stateOK(struct Inventory inventory, int* outputsCreated, struct Recipe* recipeList);
+int stateOK(struct Inventory inventory, const int* const outputsCreated, struct Recipe* recipeList);
 
 struct ItemCombination parseCombo(int itemCount, enum Type_Sort item1, enum Type_Sort item2);
 

--- a/recipes.c
+++ b/recipes.c
@@ -684,17 +684,129 @@ int stateOK(struct Inventory inventory, const int * const outputsCreated, struct
 	// List of items to not try to make
 	// Once we're done exploring the current recipe, unset it in the array
         static int dependentRecipes[NUM_RECIPES] = {0};
- 
+
         int outputsLeft[NUM_RECIPES];
-	
+
 	int startRecipe = 0;
 	int endRecipe = 0;
 
 	// Build a list of only those recipes we have not yet made
-	for (int i = 0; i < NUM_RECIPES; i++) {
-		outputsLeft[endRecipe] = i;
-		endRecipe += 1 ^ outputsCreated[i];
-	}
+	outputsLeft[endRecipe] = 0;
+	endRecipe += 1 ^ outputsCreated[0];
+	outputsLeft[endRecipe] = 1;
+	endRecipe += 1 ^ outputsCreated[1];
+	outputsLeft[endRecipe] = 2;
+	endRecipe += 1 ^ outputsCreated[2];
+	outputsLeft[endRecipe] = 3;
+	endRecipe += 1 ^ outputsCreated[3];
+	outputsLeft[endRecipe] = 4;
+	endRecipe += 1 ^ outputsCreated[4];
+	outputsLeft[endRecipe] = 5;
+	endRecipe += 1 ^ outputsCreated[5];
+	outputsLeft[endRecipe] = 6;
+	endRecipe += 1 ^ outputsCreated[6];
+	outputsLeft[endRecipe] = 7;
+	endRecipe += 1 ^ outputsCreated[7];
+	outputsLeft[endRecipe] = 8;
+	endRecipe += 1 ^ outputsCreated[8];
+	outputsLeft[endRecipe] = 9;
+	endRecipe += 1 ^ outputsCreated[9];
+	outputsLeft[endRecipe] = 10;
+	endRecipe += 1 ^ outputsCreated[10];
+	outputsLeft[endRecipe] = 11;
+	endRecipe += 1 ^ outputsCreated[11];
+	outputsLeft[endRecipe] = 12;
+	endRecipe += 1 ^ outputsCreated[12];
+	outputsLeft[endRecipe] = 13;
+	endRecipe += 1 ^ outputsCreated[13];
+	outputsLeft[endRecipe] = 14;
+	endRecipe += 1 ^ outputsCreated[14];
+	outputsLeft[endRecipe] = 15;
+	endRecipe += 1 ^ outputsCreated[15];
+	outputsLeft[endRecipe] = 16;
+	endRecipe += 1 ^ outputsCreated[16];
+	outputsLeft[endRecipe] = 17;
+	endRecipe += 1 ^ outputsCreated[17];
+	outputsLeft[endRecipe] = 18;
+	endRecipe += 1 ^ outputsCreated[18];
+	outputsLeft[endRecipe] = 19;
+	endRecipe += 1 ^ outputsCreated[19];
+	outputsLeft[endRecipe] = 20;
+	endRecipe += 1 ^ outputsCreated[20];
+	outputsLeft[endRecipe] = 21;
+	endRecipe += 1 ^ outputsCreated[21];
+	outputsLeft[endRecipe] = 22;
+	endRecipe += 1 ^ outputsCreated[22];
+	outputsLeft[endRecipe] = 23;
+	endRecipe += 1 ^ outputsCreated[23];
+	outputsLeft[endRecipe] = 24;
+	endRecipe += 1 ^ outputsCreated[24];
+	outputsLeft[endRecipe] = 25;
+	endRecipe += 1 ^ outputsCreated[25];
+	outputsLeft[endRecipe] = 26;
+	endRecipe += 1 ^ outputsCreated[26];
+	outputsLeft[endRecipe] = 27;
+	endRecipe += 1 ^ outputsCreated[27];
+	outputsLeft[endRecipe] = 28;
+	endRecipe += 1 ^ outputsCreated[28];
+	outputsLeft[endRecipe] = 29;
+	endRecipe += 1 ^ outputsCreated[29];
+	outputsLeft[endRecipe] = 30;
+	endRecipe += 1 ^ outputsCreated[30];
+	outputsLeft[endRecipe] = 31;
+	endRecipe += 1 ^ outputsCreated[31];
+	outputsLeft[endRecipe] = 32;
+	endRecipe += 1 ^ outputsCreated[32];
+	outputsLeft[endRecipe] = 33;
+	endRecipe += 1 ^ outputsCreated[33];
+	outputsLeft[endRecipe] = 34;
+	endRecipe += 1 ^ outputsCreated[34];
+	outputsLeft[endRecipe] = 35;
+	endRecipe += 1 ^ outputsCreated[35];
+	outputsLeft[endRecipe] = 36;
+	endRecipe += 1 ^ outputsCreated[36];
+	outputsLeft[endRecipe] = 37;
+	endRecipe += 1 ^ outputsCreated[37];
+	outputsLeft[endRecipe] = 38;
+	endRecipe += 1 ^ outputsCreated[38];
+	outputsLeft[endRecipe] = 39;
+	endRecipe += 1 ^ outputsCreated[39];
+	outputsLeft[endRecipe] = 40;
+	endRecipe += 1 ^ outputsCreated[40];
+	outputsLeft[endRecipe] = 41;
+	endRecipe += 1 ^ outputsCreated[41];
+	outputsLeft[endRecipe] = 42;
+	endRecipe += 1 ^ outputsCreated[42];
+	outputsLeft[endRecipe] = 43;
+	endRecipe += 1 ^ outputsCreated[43];
+	outputsLeft[endRecipe] = 44;
+	endRecipe += 1 ^ outputsCreated[44];
+	outputsLeft[endRecipe] = 45;
+	endRecipe += 1 ^ outputsCreated[45];
+	outputsLeft[endRecipe] = 46;
+	endRecipe += 1 ^ outputsCreated[46];
+	outputsLeft[endRecipe] = 47;
+	endRecipe += 1 ^ outputsCreated[47];
+	outputsLeft[endRecipe] = 48;
+	endRecipe += 1 ^ outputsCreated[48];
+	outputsLeft[endRecipe] = 49;
+	endRecipe += 1 ^ outputsCreated[49];
+	outputsLeft[endRecipe] = 50;
+	endRecipe += 1 ^ outputsCreated[50];
+	outputsLeft[endRecipe] = 51;
+	endRecipe += 1 ^ outputsCreated[51];
+	outputsLeft[endRecipe] = 52;
+	endRecipe += 1 ^ outputsCreated[52];
+	outputsLeft[endRecipe] = 53;
+	endRecipe += 1 ^ outputsCreated[53];
+	outputsLeft[endRecipe] = 54;
+	endRecipe += 1 ^ outputsCreated[54];
+	outputsLeft[endRecipe] = 55;
+	endRecipe += 1 ^ outputsCreated[55];
+	outputsLeft[endRecipe] = 56;
+	endRecipe += 1 ^ outputsCreated[56];
+	outputsLeft[endRecipe] = 57;
+	endRecipe += 1 ^ outputsCreated[57];
 
 	// Iterate through all output items that haven't been created
 	for (int currentRecipe = startRecipe; currentRecipe < endRecipe; currentRecipe++) {

--- a/recipes.c
+++ b/recipes.c
@@ -683,7 +683,7 @@ int stateOK(struct Inventory inventory, const int * const outputsCreated, struct
 
 	// List of items to not try to make
 	// Once we're done exploring the current recipe, unset it in the array
-	static int dependentRecipes[NUM_RECIPES] = {0};
+	int dependentRecipes[NUM_RECIPES] = {0};
 
 	int outputsLeft[NUM_RECIPES];
 

--- a/recipes.c
+++ b/recipes.c
@@ -683,16 +683,27 @@ int stateOK(struct Inventory inventory, const int * const outputsCreated, struct
 
 	// List of items to not try to make
 	// Once we're done exploring the current recipe, unset it in the array
-        static int dependentRecipes[NUM_RECIPES] = {0};
+	static int dependentRecipes[NUM_RECIPES] = {0};
 
-        int outputsLeft[NUM_RECIPES];
+	int outputsLeft[NUM_RECIPES];
 
 	int startRecipe = 0;
 	int endRecipe = 0;
 
 	// Build a list of only those recipes we have not yet made
+	// This loop is unrolled, treat the comments as if they apply to all
+	// iterations. With a loop this short, saving the add and cmp instructions
+	// saves a huge amount of time.
+	// Set the current end+1th member of the list to the current index
+	// This one won't get read yet
 	outputsLeft[endRecipe] = 0;
+	// If outputsCreated at the current index is 0, this will advance the end
+	// of the list to the next index, preventing the previously set value
+	// from being overwritten and allowing it to be read at the end
+	// If it's 1, then this will be a no-op and the index at end+1 will be
+	// overwritten again
 	endRecipe += 1 ^ outputsCreated[0];
+	// Loop continues
 	outputsLeft[endRecipe] = 1;
 	endRecipe += 1 ^ outputsCreated[1];
 	outputsLeft[endRecipe] = 2;


### PR DESCRIPTION
I did two big things and one small thing.

Small: 
Marked int* outputsCreated as const int* const to speed things up by just a smidge.

Big:
I pulled the check as to what work needs to be done to above the loop instead of in the loop. I make a list of the indices that aren't 1 in outputsLeft and only use those in the following loop. Before I unrolled it, it looked like this (also you can check commit 5891d6990e881ab10f0877fbc10b7de7732e0970):
```
for (int i=0; i < NUM_RECIPES; i++) {
  outputsLeft[endRecipe] = i; // Set outputsLeft to the current index
  endRecipe += 1 ^ outputsCreated[i]; // Advance only if outputsCreated is 0, advancing prevents the previous from being overwritten
}
```
Which doesn't have any conditionals. It does have the unfortunate hard read dependency on endRecipe, but I didn't figure out a way around that if I wanted to make my list using only arithmetic and memory operations.

Then I unrolled it. It's ugly, since it's that loop you see above but 58 times in a row with magic numbers. I'd rather use a #pragma style unroll, but I don't know if that works with windows and can't build for windows.

With all of that, I'm seeing StatusOk taking ~24% of the time, which is a huge improvement over the ~30% I was seeing before and most of that time is in other parts of the function like, hilariously, the (inlined) loop for placeInventoryInMakeableItems. If I could get rid of that read dependency it'd be even better.