### PR TITLE
Fix memory leaks in FTPManagement.c

### DIFF
--- a/FTPManagement.c
+++ b/FTPManagement.c
@@ -65,6 +65,7 @@ ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
 		curl_easy_setopt(curl, CURLOPT_USERAGENT, "curl/7.68.0");
 		res = curl_easy_perform(curl);
 		if (res != CURLE_OK) {
+			curl_easy_cleanup(curl);
 			return NULL;
 		}
 		

--- a/FTPManagement.c
+++ b/FTPManagement.c
@@ -137,7 +137,8 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 		cJSON *json = cJSON_Parse(wt.data);
 		char *json_str = cJSON_PrintUnformatted(json);
 		cJSON_Delete(json);
-		checkMallocFailed(json_str);
+		// TODO(TechSY730) Merge this assert function and reenable
+		// checkMallocFailed(json_str);
 		struct curl_slist *headers = NULL;
 		headers = curl_slist_append(headers, "Content-Type: application/json");
 		headers = curl_slist_append(headers, "charset: utf-8");

--- a/FTPManagement.h
+++ b/FTPManagement.h
@@ -1,4 +1,6 @@
-char *handle_get(char* url);
+#include "absl/base/port.h"
+
+ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url);
 void handle_post(char* url, FILE *fp, int localRecord, char *nickname);
 int getFastestRecordOnBlob();
 int testRecord(int localRecord);


### PR DESCRIPTION
Fix memory leaks in FTPManagement.c

There are some more memory leaks I fixed later down on my "not suitable for PR" master branch, but those will come in time.