### PR TITLE
Make tossing output more likely than first item

### DIFF
--- a/calculator.c
+++ b/calculator.c
@@ -1077,14 +1077,14 @@ void handleRecipeOutput(BranchPath *curNode, Inventory tempInventory, int tempFr
 		useDescription.framesTaken += TOSS_FRAMES;
 		useDescription.totalFramesTaken += TOSS_FRAMES;
 
+		// Evaluate the viability of tossing all current inventory items
+		// Assumed that it is impossible to toss and replace any items in the last 10 positions
+		tryTossInventoryItem(curNode, tempInventory, useDescription, tempOutputsFulfilled, numOutputsFulfilled, output, tempFrames, viableItems);
+
 		// Evaluate viability of tossing the output item itself
 		if (stateOK(tempInventory, tempOutputsFulfilled, recipeList)) {
 			finalizeLegalMove(curNode, tempFrames, useDescription, tempInventory, tempOutputsFulfilled, numOutputsFulfilled, Toss, output, -1);
 		}
-
-		// Evaluate the viability of tossing all current inventory items
-		// Assumed that it is impossible to toss and replace any items in the last 10 positions
-		tryTossInventoryItem(curNode, tempInventory, useDescription, tempOutputsFulfilled, numOutputsFulfilled, output, tempFrames, viableItems);
 	}
 }
 


### PR DESCRIPTION
This should help the optimizer have more moves to try to relocate. This could still be improved since if there are multiple recipes taking the same frames (such as multiple Mystery items), it will still alternate between moves replacing the output and moves replacing the first item instead of having all the moves replacing the output first. However, this scenario would be much harder to work around without slowing down the program, and it would occur much less frequently.