### PR TITLE
Enforce that functions that return newly allocated "things" _must_ be used.

### DIFF
--- a/CipesAtHome/CipesAtHome.vcxproj
+++ b/CipesAtHome/CipesAtHome.vcxproj
@@ -90,10 +90,14 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4141</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -105,12 +109,17 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4141</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -126,6 +135,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -147,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/CipesAtHome/CipesAtHome.vcxproj.filters
+++ b/CipesAtHome/CipesAtHome.vcxproj.filters
@@ -33,13 +33,13 @@
     <ClCompile Include="..\config.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\recipes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\FTPManagement.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\start.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\recipes.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\shutdown.c">
@@ -74,6 +74,9 @@
     <ClInclude Include="..\start.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\shutdown.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\absl\base\attributes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -90,9 +93,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\absl\base\port.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\shutdown.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FTPManagement.c
+++ b/FTPManagement.c
@@ -29,7 +29,7 @@ struct memory {
 static size_t write_data(char *contents, size_t size, size_t nmemb, void *userdata) {
 	size_t realsize = size * nmemb;
 	struct memory *mem = (struct memory *)userdata;
-	
+
 	char *ptr = realloc(mem->data, mem->size + realsize + 1);
 	if (ptr == NULL)
 		return 0;
@@ -43,14 +43,14 @@ static size_t write_data(char *contents, size_t size, size_t nmemb, void *userda
 /*-------------------------------------------------------------------
  * Function 	: handle_get
  * Inputs	: char	*url
- * Outputs	: char	*data	
+ * Outputs	: char	*data
  *
  * This is the main cURL GET function. Communicate with either GitHub
  * or the Blob server to obtain either the latest program version or
  * the current fastest frame record respectively.
  * The returning value (if non-NULL) MUST be freed.
  -------------------------------------------------------------------*/
-ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
+ABSL_MUST_USE_RESULT char *handle_get(char* url) {
 	CURL *curl;
 	struct memory chunk;
 	chunk.data = NULL;
@@ -68,7 +68,7 @@ ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
 			curl_easy_cleanup(curl);
 			return NULL;
 		}
-		
+
 		curl_easy_cleanup(curl);
 	}
 
@@ -77,8 +77,8 @@ ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
 
 /*-------------------------------------------------------------------
  * Function 	: getFastestRecordOnBlob
- * Inputs	: 
- * Outputs	: int record	
+ * Inputs	:
+ * Outputs	: int record
  *
  * Retrieve the server's current fastest roadmap length.
  -------------------------------------------------------------------*/
@@ -92,9 +92,9 @@ int getFastestRecordOnBlob() {
 		free(data);
 		return record;
 	}
-	
+
 	// Log
-	
+
 	return 0;
 }
 
@@ -113,7 +113,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 	struct memory rt;
 	rt.data = NULL;
 	rt.size = 0;
-	
+
 	fseek(fp, 0, SEEK_END);
 	long fsize = ftell(fp);
 	fseek(fp, 0, SEEK_SET);
@@ -142,7 +142,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 		struct curl_slist *headers = NULL;
 		headers = curl_slist_append(headers, "Content-Type: application/json");
 		headers = curl_slist_append(headers, "charset: utf-8");
-		
+
 		curl_easy_setopt(curl, CURLOPT_URL, url);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_str);
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
@@ -151,7 +151,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 		curl_easy_perform(curl);
 		curl_slist_free_all(headers);
 		free(json_str);
-		
+
 		curl_easy_cleanup(curl);
 	}
 	curl_global_cleanup();
@@ -193,7 +193,7 @@ int testRecord(int localRecord) {
 	strncpy(nickname, username, 19);
 	nickname[19] = '\0';
 	handle_post("https://hundorecipes.azurewebsites.net/api/uploadAndVerify", fp, localRecord, nickname);
-	
+
 	return 0;
 }
 
@@ -216,18 +216,18 @@ int checkForUpdates(const char *local_ver) {
 	cJSON *json_item = cJSON_GetObjectItemCaseSensitive(json, "tag_name");
 	char *ver = cJSON_GetStringValue(json_item);
 	free(data);
-	
+
 	if (ver == NULL) {
 		cJSON_Delete(json);
 		return -1;
 	}
-	
+
 	// Compare local version with github version
 	if (strncmp(local_ver, ver, 4) != 0) {
 		cJSON_Delete(json);
 		return 1;
 	}
-	
+
 	// Add logs
 	cJSON_Delete(json);
 	return 0;

--- a/FTPManagement.h
+++ b/FTPManagement.h
@@ -1,6 +1,7 @@
 #include "absl/base/port.h"
 
-ABSL_MUST_USE_RESULT char *handle_get(char* url);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
+char *handle_get(char* url);
 void handle_post(char* url, FILE *fp, int localRecord, char *nickname);
 int getFastestRecordOnBlob();
 int testRecord(int localRecord);

--- a/FTPManagement.h
+++ b/FTPManagement.h
@@ -1,6 +1,6 @@
 #include "absl/base/port.h"
 
-ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url);
+ABSL_MUST_USE_RESULT char *handle_get(char* url);
 void handle_post(char* url, FILE *fp, int localRecord, char *nickname);
 int getFastestRecordOnBlob();
 int testRecord(int localRecord);

--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -431,20 +431,12 @@
 // Note: past advice was to place the macro after the argument list.
 #if ABSL_HAVE_CPP_ATTRIBUTE(nodiscard)
 #define ABSL_MUST_USE_RESULT [[nodiscard]]
-#elif defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)
+#elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
 #define ABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
 #else
 #define ABSL_MUST_USE_RESULT
 #endif
 
-// Same as above, but allows GCC
-#if ABSL_HAVE_CPP_ATTRIBUTE(nodiscard)
-#define ABSL_MUST_USE_RESULT_INCLUSIVE [[nodiscard]]
-#elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
-#define ABSL_MUST_USE_RESULT_INCLUSIVE __attribute__((warn_unused_result))
-#else
-#define ABSL_MUST_USE_RESULT_INCLUSIVE
-#endif
 
 // ABSL_ATTRIBUTE_HOT, ABSL_ATTRIBUTE_COLD
 //

--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -433,6 +433,8 @@
 #define ABSL_MUST_USE_RESULT [[nodiscard]]
 #elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
 #define ABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && _MSC_VER >= 1200
+#define ABSL_MUST_USE_RESULT _Check_return_
 #else
 #define ABSL_MUST_USE_RESULT
 #endif

--- a/calculator.c
+++ b/calculator.c
@@ -101,7 +101,7 @@ void applyJumpStorageFramePenalty(BranchPath *node) {
  * Outputs	:
  * A simple memcpy to duplicate oldOutputsFulfilled to a new array
  -------------------------------------------------------------------*/
-int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
+ABSL_MUST_USE_RESULT int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
 	int *newOutputsFulfilled = malloc(sizeof(int) * NUM_RECIPES);
 
 	if (newOutputsFulfilled == NULL) {
@@ -129,8 +129,9 @@ int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
  * lateSort tracks whether we performed the sort before or after the
  * Keel Mango, for printing purposes
  -------------------------------------------------------------------*/
-CH5 *createChapter5Struct(CH5_Eval eval, int lateSort) {
+ABSL_MUST_USE_RESULT CH5 *createChapter5Struct(CH5_Eval eval, int lateSort) {
 	CH5 *ch5 = malloc(sizeof(CH5));
+
 
 	if (ch5 == NULL) {
 		printf("Fatal error! Ran out of heap memory.\n");
@@ -307,7 +308,7 @@ void createCookDescription2Items(BranchPath *node, Recipe recipe, ItemCombinatio
  *
  * Given the input parameters, allocate and set attributes for a legalMove node
  -------------------------------------------------------------------*/
-BranchPath *createLegalMove(BranchPath *node, Inventory inventory, MoveDescription description, int *outputsFulfilled, int numOutputsFulfilled) {
+ABSL_MUST_USE_RESULT BranchPath *createLegalMove(BranchPath *node, Inventory inventory, MoveDescription description, int *outputsFulfilled, int numOutputsFulfilled) {
 	BranchPath *newLegalMove = malloc(sizeof(BranchPath));
 
 	if (newLegalMove == NULL) {
@@ -1156,7 +1157,7 @@ void handleSorts(BranchPath *curNode) {
  *
  * Generate the root of the tree graph
  -------------------------------------------------------------------*/
-BranchPath *initializeRoot() {
+ABSL_MUST_USE_RESULT BranchPath *initializeRoot() {
 	BranchPath *root = malloc(sizeof(BranchPath));
 
 	if (root == NULL) {

--- a/calculator.h
+++ b/calculator.h
@@ -3,6 +3,7 @@
 #include "inventory.h"
 #include "recipes.h"
 #include "start.h"
+#include "absl/base/attributes.h"
 
 // Represent the action at a particular node in the roadmap
 enum Action {
@@ -98,6 +99,7 @@ int removeRecipesForReallocation(struct BranchPath *node, enum Type_Sort *rearra
 
 // Legal move functions
 
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct BranchPath* createLegalMove(struct BranchPath* node, struct Inventory inventory, struct MoveDescription description, int* outputsFulfilled, int numOutputsFulfilled);
 void filterOut2Ingredients(struct BranchPath* node);
 void finalizeChapter5Eval(struct BranchPath* node, struct Inventory inventory, struct CH5* ch5Data, int temp_frame_sum, int* outputsFulfilled, int numOutputsFulfilled);
@@ -128,6 +130,7 @@ void handleChapter5LateSortEndItems(struct BranchPath* node, struct Inventory in
 void handleDBCOAllocation0Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
 void handleDBCOAllocation1Null(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
 void handleDBCOAllocation2Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct CH5* createChapter5Struct(struct CH5_Eval eval, int lateSort);
 
 // Initialization functions
@@ -166,9 +169,11 @@ int selectSecondItemFirst(int* ingredientLoc, int nulls, int viableItems);
 void swapItems(int* ingredientLoc);
 
 // General node functions
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 int *copyOutputsFulfilled(int *oldOutputsFulfilled);
 void freeAllNodes(struct BranchPath* node);
 void freeNode(struct BranchPath *node);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct BranchPath* initializeRoot();
 
 // Other

--- a/inventory.c
+++ b/inventory.c
@@ -341,7 +341,7 @@ char *getItemName(Type_Sort t_key) {
 
 /*-------------------------------------------------------------------
  * Function 	: getInventoryFrames
- * Inputs	: 
+ * Inputs	:
  * Outputs	: int **inv_frames
  *
  * Returns a double pointer which can be used to reference how many
@@ -378,7 +378,7 @@ int **getInventoryFrames() {
 
 /*-------------------------------------------------------------------
  * Function 	: getStartingInventory
- * Inputs	: 
+ * Inputs	:
  * Outputs	: enum Type_Sort *inventory
  *
  * Returns a pointer to an array which contains all items we start with
@@ -407,7 +407,7 @@ struct Inventory getStartingInventory() {
 	inventory.inventory[17] = Maple_Syrup;
 	inventory.inventory[18] = Hot_Sauce;
 	inventory.inventory[19] = Jammin_Jelly;
-	
+
 	return inventory;
 }
 

--- a/inventory.h
+++ b/inventory.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "recipes.h"
+#include "absl/base/attributes.h"
 
 enum Alpha_Sort {
 	POW_Block_a,
@@ -247,6 +248,7 @@ struct Recipe {
 
 // Recipe functions
 int getIndexOfRecipe(enum Type_Sort item);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct Recipe* getRecipeList();
 int stateOK(struct Inventory inventory, const int* const outputsCreated, struct Recipe* recipeList);
 

--- a/recipes.c
+++ b/recipes.c
@@ -3,6 +3,7 @@
 #include "recipes.h"
 #include <string.h>
 #include "inventory.h"
+#include "absl/base/port.h"
 
 #define NUM_RECIPES 58 // Including Dried Bouquet trade
 #define NUM_ITEMS 107 // All listed items
@@ -30,7 +31,7 @@ struct ItemCombination parseCombo(int itemCount, enum Type_Sort item1, enum Type
  * Hard-coded array which tracks all recipes, the number of combinations
  * for each recipe, and the items that make up each of those combos.
  -------------------------------------------------------------------*/
-struct Recipe* getRecipeList() {
+ABSL_MUST_USE_RESULT struct Recipe* getRecipeList() {
 	struct Recipe* recipes = malloc(sizeof(struct Recipe) * NUM_RECIPES);
 
 	// Begin hard-coding recipes


### PR DESCRIPTION
Enforce that functions that return newly allocated "things" _must_ be used.

They need to be freed at some point; so throwing away the result will make a memory leak.

Also fixes some consistency between build config issues in the VC project.