### PR TITLE
Fix a big source of malloc churn, the outputCreated array.

### DIFF
--- a/CipesAtHome/CipesAtHome.vcxproj
+++ b/CipesAtHome/CipesAtHome.vcxproj
@@ -90,10 +90,14 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4141</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -105,12 +109,17 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <OpenMPSupport>true</OpenMPSupport>
+      <DisableSpecificWarnings>4141</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>..\</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -126,6 +135,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -147,6 +157,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/CipesAtHome/CipesAtHome.vcxproj.filters
+++ b/CipesAtHome/CipesAtHome.vcxproj.filters
@@ -33,13 +33,13 @@
     <ClCompile Include="..\config.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\recipes.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\FTPManagement.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\start.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\recipes.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\shutdown.c">
@@ -74,6 +74,9 @@
     <ClInclude Include="..\start.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\shutdown.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\absl\base\attributes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -90,9 +93,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\absl\base\port.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\shutdown.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FTPManagement.c
+++ b/FTPManagement.c
@@ -29,7 +29,7 @@ struct memory {
 static size_t write_data(char *contents, size_t size, size_t nmemb, void *userdata) {
 	size_t realsize = size * nmemb;
 	struct memory *mem = (struct memory *)userdata;
-	
+
 	char *ptr = realloc(mem->data, mem->size + realsize + 1);
 	if (ptr == NULL)
 		return 0;
@@ -43,14 +43,14 @@ static size_t write_data(char *contents, size_t size, size_t nmemb, void *userda
 /*-------------------------------------------------------------------
  * Function 	: handle_get
  * Inputs	: char	*url
- * Outputs	: char	*data	
+ * Outputs	: char	*data
  *
  * This is the main cURL GET function. Communicate with either GitHub
  * or the Blob server to obtain either the latest program version or
  * the current fastest frame record respectively.
  * The returning value (if non-NULL) MUST be freed.
  -------------------------------------------------------------------*/
-ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
+ABSL_MUST_USE_RESULT char *handle_get(char* url) {
 	CURL *curl;
 	struct memory chunk;
 	chunk.data = NULL;
@@ -68,7 +68,7 @@ ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
 			curl_easy_cleanup(curl);
 			return NULL;
 		}
-		
+
 		curl_easy_cleanup(curl);
 	}
 
@@ -77,8 +77,8 @@ ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url) {
 
 /*-------------------------------------------------------------------
  * Function 	: getFastestRecordOnBlob
- * Inputs	: 
- * Outputs	: int record	
+ * Inputs	:
+ * Outputs	: int record
  *
  * Retrieve the server's current fastest roadmap length.
  -------------------------------------------------------------------*/
@@ -92,9 +92,9 @@ int getFastestRecordOnBlob() {
 		free(data);
 		return record;
 	}
-	
+
 	// Log
-	
+
 	return 0;
 }
 
@@ -113,7 +113,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 	struct memory rt;
 	rt.data = NULL;
 	rt.size = 0;
-	
+
 	fseek(fp, 0, SEEK_END);
 	long fsize = ftell(fp);
 	fseek(fp, 0, SEEK_SET);
@@ -142,7 +142,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 		struct curl_slist *headers = NULL;
 		headers = curl_slist_append(headers, "Content-Type: application/json");
 		headers = curl_slist_append(headers, "charset: utf-8");
-		
+
 		curl_easy_setopt(curl, CURLOPT_URL, url);
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_str);
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
@@ -151,7 +151,7 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 		curl_easy_perform(curl);
 		curl_slist_free_all(headers);
 		free(json_str);
-		
+
 		curl_easy_cleanup(curl);
 	}
 	curl_global_cleanup();
@@ -193,7 +193,7 @@ int testRecord(int localRecord) {
 	strncpy(nickname, username, 19);
 	nickname[19] = '\0';
 	handle_post("https://hundorecipes.azurewebsites.net/api/uploadAndVerify", fp, localRecord, nickname);
-	
+
 	return 0;
 }
 
@@ -216,18 +216,18 @@ int checkForUpdates(const char *local_ver) {
 	cJSON *json_item = cJSON_GetObjectItemCaseSensitive(json, "tag_name");
 	char *ver = cJSON_GetStringValue(json_item);
 	free(data);
-	
+
 	if (ver == NULL) {
 		cJSON_Delete(json);
 		return -1;
 	}
-	
+
 	// Compare local version with github version
 	if (strncmp(local_ver, ver, 4) != 0) {
 		cJSON_Delete(json);
 		return 1;
 	}
-	
+
 	// Add logs
 	cJSON_Delete(json);
 	return 0;

--- a/FTPManagement.h
+++ b/FTPManagement.h
@@ -1,6 +1,7 @@
 #include "absl/base/port.h"
 
-ABSL_MUST_USE_RESULT char *handle_get(char* url);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
+char *handle_get(char* url);
 void handle_post(char* url, FILE *fp, int localRecord, char *nickname);
 int getFastestRecordOnBlob();
 int testRecord(int localRecord);

--- a/FTPManagement.h
+++ b/FTPManagement.h
@@ -1,6 +1,6 @@
 #include "absl/base/port.h"
 
-ABSL_MUST_USE_RESULT_INCLUSIVE char *handle_get(char* url);
+ABSL_MUST_USE_RESULT char *handle_get(char* url);
 void handle_post(char* url, FILE *fp, int localRecord, char *nickname);
 int getFastestRecordOnBlob();
 int testRecord(int localRecord);

--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -431,20 +431,12 @@
 // Note: past advice was to place the macro after the argument list.
 #if ABSL_HAVE_CPP_ATTRIBUTE(nodiscard)
 #define ABSL_MUST_USE_RESULT [[nodiscard]]
-#elif defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)
+#elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
 #define ABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
 #else
 #define ABSL_MUST_USE_RESULT
 #endif
 
-// Same as above, but allows GCC
-#if ABSL_HAVE_CPP_ATTRIBUTE(nodiscard)
-#define ABSL_MUST_USE_RESULT_INCLUSIVE [[nodiscard]]
-#elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
-#define ABSL_MUST_USE_RESULT_INCLUSIVE __attribute__((warn_unused_result))
-#else
-#define ABSL_MUST_USE_RESULT_INCLUSIVE
-#endif
 
 // ABSL_ATTRIBUTE_HOT, ABSL_ATTRIBUTE_COLD
 //

--- a/absl/base/attributes.h
+++ b/absl/base/attributes.h
@@ -433,6 +433,8 @@
 #define ABSL_MUST_USE_RESULT [[nodiscard]]
 #elif (defined(__clang__) && ABSL_HAVE_ATTRIBUTE(warn_unused_result)) || defined(__GNUC__)
 #define ABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && _MSC_VER >= 1200
+#define ABSL_MUST_USE_RESULT _Check_return_
 #else
 #define ABSL_MUST_USE_RESULT
 #endif

--- a/calculator.c
+++ b/calculator.c
@@ -101,7 +101,7 @@ void applyJumpStorageFramePenalty(BranchPath *node) {
  * Outputs	:
  * A simple memcpy to duplicate oldOutputsFulfilled to a new array
  -------------------------------------------------------------------*/
-int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
+ABSL_MUST_USE_RESULT int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
 	int *newOutputsFulfilled = malloc(sizeof(int) * NUM_RECIPES);
 
 	if (newOutputsFulfilled == NULL) {
@@ -129,8 +129,9 @@ int *copyOutputsFulfilled(int *oldOutputsFulfilled) {
  * lateSort tracks whether we performed the sort before or after the
  * Keel Mango, for printing purposes
  -------------------------------------------------------------------*/
-CH5 *createChapter5Struct(CH5_Eval eval, int lateSort) {
+ABSL_MUST_USE_RESULT CH5 *createChapter5Struct(CH5_Eval eval, int lateSort) {
 	CH5 *ch5 = malloc(sizeof(CH5));
+
 
 	if (ch5 == NULL) {
 		printf("Fatal error! Ran out of heap memory.\n");
@@ -307,7 +308,7 @@ void createCookDescription2Items(BranchPath *node, Recipe recipe, ItemCombinatio
  *
  * Given the input parameters, allocate and set attributes for a legalMove node
  -------------------------------------------------------------------*/
-BranchPath *createLegalMove(BranchPath *node, Inventory inventory, MoveDescription description, int *outputsFulfilled, int numOutputsFulfilled) {
+ABSL_MUST_USE_RESULT BranchPath *createLegalMove(BranchPath *node, Inventory inventory, MoveDescription description, int *outputsFulfilled, int numOutputsFulfilled) {
 	BranchPath *newLegalMove = malloc(sizeof(BranchPath));
 
 	if (newLegalMove == NULL) {
@@ -1156,7 +1157,7 @@ void handleSorts(BranchPath *curNode) {
  *
  * Generate the root of the tree graph
  -------------------------------------------------------------------*/
-BranchPath *initializeRoot() {
+ABSL_MUST_USE_RESULT BranchPath *initializeRoot() {
 	BranchPath *root = malloc(sizeof(BranchPath));
 
 	if (root == NULL) {

--- a/calculator.h
+++ b/calculator.h
@@ -3,6 +3,7 @@
 #include "inventory.h"
 #include "recipes.h"
 #include "start.h"
+#include "absl/base/attributes.h"
 
 // Represent the action at a particular node in the roadmap
 enum Action {
@@ -98,6 +99,7 @@ int removeRecipesForReallocation(struct BranchPath *node, enum Type_Sort *rearra
 
 // Legal move functions
 
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct BranchPath* createLegalMove(struct BranchPath* node, struct Inventory inventory, struct MoveDescription description, int* outputsFulfilled, int numOutputsFulfilled);
 void filterOut2Ingredients(struct BranchPath* node);
 void finalizeChapter5Eval(struct BranchPath* node, struct Inventory inventory, struct CH5* ch5Data, int temp_frame_sum, int* outputsFulfilled, int numOutputsFulfilled);
@@ -128,6 +130,7 @@ void handleChapter5LateSortEndItems(struct BranchPath* node, struct Inventory in
 void handleDBCOAllocation0Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
 void handleDBCOAllocation1Null(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
 void handleDBCOAllocation2Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct CH5* createChapter5Struct(struct CH5_Eval eval, int lateSort);
 
 // Initialization functions
@@ -166,9 +169,11 @@ int selectSecondItemFirst(int* ingredientLoc, int nulls, int viableItems);
 void swapItems(int* ingredientLoc);
 
 // General node functions
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 int *copyOutputsFulfilled(int *oldOutputsFulfilled);
 void freeAllNodes(struct BranchPath* node);
 void freeNode(struct BranchPath *node);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct BranchPath* initializeRoot();
 
 // Other

--- a/calculator.h
+++ b/calculator.h
@@ -1,5 +1,6 @@
 #ifndef CALCULATOR_H
 #define CALCULATOR_H
+#include <stdbool.h>
 #include "inventory.h"
 #include "recipes.h"
 #include "start.h"
@@ -78,7 +79,7 @@ struct BranchPath {
 	struct MoveDescription description;
 	struct BranchPath *prev;
 	struct BranchPath *next;
-	int *outputCreated;					// Array of 58 items, 1 if item was produced, 0 if not; indexed by recipe ordering
+	outputCreatedArray_t outputCreated;					// Array of 58 items, true if item was produced, false if not; indexed by recipe ordering
 	int numOutputsCreated;				// Number of valid outputCreated entries to eliminate a lengthy for-loop
 	struct BranchPath **legalMoves;		// Represents possible next paths to take
 	int numLegalMoves;
@@ -92,45 +93,55 @@ struct OptimizeResult {
 };
 
 // optimizeRoadmap functions
-struct BranchPath* copyAllNodes(struct BranchPath* newNode, struct BranchPath* oldNode);
-struct OptimizeResult optimizeRoadmap(struct BranchPath* root);
-void reallocateRecipes(struct BranchPath *newRoot, enum Type_Sort *rearranged_recipes, int num_rearranged_recipes);
+struct BranchPath* copyAllNodes(struct BranchPath* newNode, const struct BranchPath* oldNode);
+struct OptimizeResult optimizeRoadmap(const struct BranchPath* root);
+void reallocateRecipes(struct BranchPath *newRoot, const enum Type_Sort *rearranged_recipes, int num_rearranged_recipes);
 int removeRecipesForReallocation(struct BranchPath *node, enum Type_Sort *rearranged_recipes);
 
 // Legal move functions
 
 ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
-struct BranchPath* createLegalMove(struct BranchPath* node, struct Inventory inventory, struct MoveDescription description, int* outputsFulfilled, int numOutputsFulfilled);
+struct BranchPath* createLegalMove(struct BranchPath* node, struct Inventory inventory, struct MoveDescription description, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled);
 void filterOut2Ingredients(struct BranchPath* node);
-void finalizeChapter5Eval(struct BranchPath* node, struct Inventory inventory, struct CH5* ch5Data, int temp_frame_sum, int* outputsFulfilled, int numOutputsFulfilled);
-void finalizeLegalMove(struct BranchPath* node, int tempFrames, struct MoveDescription useDescription, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, enum HandleOutput tossType, enum Type_Sort toss, int tossIndex);
+void finalizeChapter5Eval(struct BranchPath* node, struct Inventory inventory, struct CH5* ch5Data, int temp_frame_sum, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled);
+void finalizeLegalMove(struct BranchPath* node, int tempFrames, struct MoveDescription useDescription, struct Inventory tempInventory, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, enum HandleOutput tossType, enum Type_Sort toss, int tossIndex);
 void freeLegalMove(struct BranchPath* node, int index);
-int getInsertionIndex(struct BranchPath* node, int frames);
+int getInsertionIndex(const struct BranchPath* node, int frames);
 void insertIntoLegalMoves(int insertIndex, struct BranchPath* newLegalMove, struct BranchPath* curNode);
 void popAllButFirstLegalMove(struct BranchPath* node);
 void shiftDownLegalMoves(struct BranchPath *node, int lowerBound, int uppderBound);
 void shiftUpLegalMoves(struct BranchPath* node, int startIndex);
 
 // Cooking functions
-void copyCook(struct Cook* cookNew, struct Cook* cookOld);
-void createCookDescription2Items(struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
-void createCookDescription1Item(struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
-struct MoveDescription createCookDescription(struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory *tempInventory, int* tempFrames, int viableItems);
+
+/*-------------------------------------------------------------------
+ * Function 	: copyCook
+ * Inputs	: struct Cook *cookNew
+ *		  struct Cook *cookOld
+ *
+ * A simple function to copy the data within cookOld to cookNew.
+ -------------------------------------------------------------------*/
+ABSL_ATTRIBUTE_ALWAYS_INLINE inline void copyCook(struct Cook *cookNew, struct Cook *cookOld) {
+	*cookNew = *cookOld;
+	return;
+}
+void createCookDescription2Items(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
+void createCookDescription1Item(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
+struct MoveDescription createCookDescription(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory *tempInventory, int* tempFrames, int viableItems);
 void fulfillRecipes(struct BranchPath* curNode);
-void generateCook(struct MoveDescription* description, struct ItemCombination combo, struct Recipe recipe, int* ingredientLoc, int swap);
-void handleRecipeOutput(struct BranchPath* curNode, struct Inventory tempInventory, int tempFrames, struct MoveDescription useDescription, int* tempOutputsFulfilled, int numOutputsFulfilled, enum Type_Sort output, int viableItems);
-void tryTossInventoryItem(struct BranchPath* curNode, struct Inventory tempInventory, struct MoveDescription useDescription, int* tempOutputsFulfilled, int numOutputsFulfilled, enum Type_Sort output, int tempFrames, int viableItems);
+void generateCook(struct MoveDescription* description, const struct ItemCombination combo, const struct Recipe recipe, const int* ingredientLoc, int swap);
+void handleRecipeOutput(struct BranchPath* curNode, struct Inventory tempInventory, int tempFrames, struct MoveDescription useDescription, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, enum Type_Sort output, int viableItems);
+void tryTossInventoryItem(struct BranchPath* curNode, struct Inventory tempInventory, struct MoveDescription useDescription, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, enum Type_Sort output, int tempFrames, int viableItems);
 
 // Chapter 5 functions
 void fulfillChapter5(struct BranchPath* curNode);
-void handleChapter5Eval(struct BranchPath* node, struct Inventory inventory, int* outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleChapter5EarlySortEndItems(struct BranchPath* node, struct Inventory inventory, int* outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleChapter5Sorts(struct BranchPath* node, struct Inventory inventory, int* outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleChapter5LateSortEndItems(struct BranchPath* node, struct Inventory inventory, int* outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleDBCOAllocation0Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleDBCOAllocation1Null(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-void handleDBCOAllocation2Nulls(struct BranchPath* curNode, struct Inventory tempInventory, int* tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
-ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
+void handleChapter5Eval(struct BranchPath* node, struct Inventory inventory, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleChapter5EarlySortEndItems(struct BranchPath* node, struct Inventory inventory, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleChapter5Sorts(struct BranchPath* node, struct Inventory inventory, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleChapter5LateSortEndItems(struct BranchPath* node, struct Inventory inventory, const outputCreatedArray_t outputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleDBCOAllocation0Nulls(struct BranchPath* curNode, struct Inventory tempInventory, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleDBCOAllocation1Null(struct BranchPath* curNode, struct Inventory tempInventory, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
+void handleDBCOAllocation2Nulls(struct BranchPath* curNode, struct Inventory tempInventory, const outputCreatedArray_t tempOutputsFulfilled, int numOutputsFulfilled, struct CH5_Eval eval);
 struct CH5* createChapter5Struct(struct CH5_Eval eval, int lateSort);
 
 // Initialization functions
@@ -138,14 +149,14 @@ void initializeInvFrames();
 void initializeRecipeList();
 
 // File output functions
-void printCh5Data(struct BranchPath* curNode, struct MoveDescription desc, FILE* fp);
-void printCh5Sort(struct CH5* ch5Data, FILE* fp);
-void printCookData(struct BranchPath* curNode, struct MoveDescription desc, FILE* fp);
+void printCh5Data(const struct BranchPath* curNode, const struct MoveDescription desc, FILE* fp);
+void printCh5Sort(const struct CH5* ch5Data, FILE* fp);
+void printCookData(const struct BranchPath* curNode, const struct MoveDescription desc, FILE* fp);
 void printFileHeader(FILE* fp);
-void printInventoryData(struct BranchPath* curNode, FILE* fp);
-void printOutputsCreated(struct BranchPath* curNode, FILE* fp);
-void printNodeDescription(struct BranchPath * curNode, FILE * fp);
-void printResults(char* filename, struct BranchPath* path);
+void printInventoryData(const struct BranchPath* curNode, FILE* fp);
+void printOutputsCreated(const struct BranchPath* curNode, FILE* fp);
+void printNodeDescription(const struct BranchPath * curNode, FILE * fp);
+void printResults(const char* filename, const struct BranchPath* path);
 void printSortData(FILE* fp, enum Action curNodeAction);
 
 // Select and random methodology functions
@@ -164,21 +175,17 @@ int type_sort_reverse(const void* elem1, const void* elem2);
 
 // Frame calculation and optimization functions
 void applyJumpStorageFramePenalty(struct BranchPath *node);
-void generateFramesTaken(struct MoveDescription* description, struct BranchPath* node, int framesTaken);
-int selectSecondItemFirst(int* ingredientLoc, int nulls, int viableItems);
+void generateFramesTaken(struct MoveDescription* description, const struct BranchPath* node, int framesTaken);
+int selectSecondItemFirst(const int* ingredientLoc, int nulls, int viableItems);
 void swapItems(int* ingredientLoc);
 
 // General node functions
-ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
-int *copyOutputsFulfilled(int *oldOutputsFulfilled);
 void freeAllNodes(struct BranchPath* node);
 void freeNode(struct BranchPath *node);
-ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct BranchPath* initializeRoot();
 
 // Other
 void periodicGithubCheck();
-void logIterations(int ID, int stepIndex, struct BranchPath * curNode, int iterationCount, int level);
 struct Result calculateOrder(int ID);
 
 #endif

--- a/calculator.h
+++ b/calculator.h
@@ -114,17 +114,6 @@ void shiftUpLegalMoves(struct BranchPath* node, int startIndex);
 
 // Cooking functions
 
-/*-------------------------------------------------------------------
- * Function 	: copyCook
- * Inputs	: struct Cook *cookNew
- *		  struct Cook *cookOld
- *
- * A simple function to copy the data within cookOld to cookNew.
- -------------------------------------------------------------------*/
-ABSL_ATTRIBUTE_ALWAYS_INLINE inline void copyCook(struct Cook *cookNew, struct Cook *cookOld) {
-	*cookNew = *cookOld;
-	return;
-}
 void createCookDescription2Items(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
 void createCookDescription1Item(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory* tempInventory, int* ingredientLoc, int* tempFrames, int viableItems, struct MoveDescription* useDescription);
 struct MoveDescription createCookDescription(const struct BranchPath* node, struct Recipe recipe, struct ItemCombination combo, struct Inventory *tempInventory, int* tempFrames, int viableItems);

--- a/inventory.c
+++ b/inventory.c
@@ -341,7 +341,7 @@ char *getItemName(Type_Sort t_key) {
 
 /*-------------------------------------------------------------------
  * Function 	: getInventoryFrames
- * Inputs	: 
+ * Inputs	:
  * Outputs	: int **inv_frames
  *
  * Returns a double pointer which can be used to reference how many
@@ -378,7 +378,7 @@ int **getInventoryFrames() {
 
 /*-------------------------------------------------------------------
  * Function 	: getStartingInventory
- * Inputs	: 
+ * Inputs	:
  * Outputs	: enum Type_Sort *inventory
  *
  * Returns a pointer to an array which contains all items we start with
@@ -407,7 +407,7 @@ struct Inventory getStartingInventory() {
 	inventory.inventory[17] = Maple_Syrup;
 	inventory.inventory[18] = Hot_Sauce;
 	inventory.inventory[19] = Jammin_Jelly;
-	
+
 	return inventory;
 }
 

--- a/inventory.h
+++ b/inventory.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "recipes.h"
+#include "absl/base/attributes.h"
 
 enum Alpha_Sort {
 	POW_Block_a,
@@ -247,6 +248,7 @@ struct Recipe {
 
 // Recipe functions
 int getIndexOfRecipe(enum Type_Sort item);
+ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct Recipe* getRecipeList();
 int stateOK(struct Inventory inventory, const int* const outputsCreated, struct Recipe* recipeList);
 

--- a/inventory.h
+++ b/inventory.h
@@ -250,7 +250,7 @@ struct Recipe {
 int getIndexOfRecipe(enum Type_Sort item);
 ABSL_MUST_USE_RESULT  // Output is newly allocated and needs to be freed at some point
 struct Recipe* getRecipeList();
-int stateOK(struct Inventory inventory, const int* const outputsCreated, struct Recipe* recipeList);
+int stateOK(struct Inventory inventory, const outputCreatedArray_t outputsCreated, struct Recipe* recipeList);
 
 struct ItemCombination parseCombo(int itemCount, enum Type_Sort item1, enum Type_Sort item2);
 

--- a/recipes.c
+++ b/recipes.c
@@ -3,6 +3,7 @@
 #include "recipes.h"
 #include <string.h>
 #include "inventory.h"
+#include "recipes.h"
 #include "absl/base/port.h"
 
 #define NUM_RECIPES 58 // Including Dried Bouquet trade
@@ -574,8 +575,8 @@ int getIndexOfRecipe(enum Type_Sort item) {
  *
  * A simple memcpy to duplicate a previous instance of dependentRecipes.
  -------------------------------------------------------------------*/
-void copyDependentRecipes(int *newDependentRecipes, int *dependentRecipes) {
-	memcpy((void *)newDependentRecipes, (void *)dependentRecipes, sizeof(int) * NUM_RECIPES);
+void copyDependentRecipes(int *newDependentRecipes, const int *dependentRecipes) {
+	memcpy((void *)newDependentRecipes, (const void *)dependentRecipes, sizeof(int) * NUM_RECIPES);
 }
 
 /*-------------------------------------------------------------------
@@ -592,7 +593,7 @@ void copyDependentRecipes(int *newDependentRecipes, int *dependentRecipes) {
  * be creatable.
  -------------------------------------------------------------------*/
 // Returns 1 if true, 0 if false
-int checkRecipe(struct ItemCombination combo, int *makeableItems, const int * const outputsCreated, int *dependentRecipes, struct Recipe *recipeList) {
+int checkRecipe(struct ItemCombination combo, int *makeableItems, const outputCreatedArray_t outputsCreated, int *dependentRecipes, struct Recipe *recipeList) {
 	// Determine if the recipe items can still be fulfilled
 	for (int i = 0; i < combo.numItems; i++) {
 		enum Type_Sort ingredient = i == 0 ? combo.item1 : combo.item2;
@@ -662,7 +663,7 @@ int checkRecipe(struct ItemCombination combo, int *makeableItems, const int * co
  * been already created, and calls checkRecipe to see if each remaining
  * recipe can still be fulfilled at some point in the roadmap.
  -------------------------------------------------------------------*/
-int stateOK(struct Inventory inventory, const int * const outputsCreated, struct Recipe *recipeList) {
+int stateOK(struct Inventory inventory, const outputCreatedArray_t outputsCreated, struct Recipe *recipeList) {
 	// With the given inventory, can the remaining recipes be fulfilled?
 
 	// If Chapter 5 has not been done, verify that Thunder Rage is in the inventory
@@ -703,122 +704,122 @@ int stateOK(struct Inventory inventory, const int * const outputsCreated, struct
 	// from being overwritten and allowing it to be read at the end
 	// If it's 1, then this will be a no-op and the index at end+1 will be
 	// overwritten again
-	endRecipe += 1 ^ outputsCreated[0];
+	endRecipe += !outputsCreated[0];
 	// Loop continues
 	outputsLeft[endRecipe] = 1;
-	endRecipe += 1 ^ outputsCreated[1];
+	endRecipe += !outputsCreated[1];
 	outputsLeft[endRecipe] = 2;
-	endRecipe += 1 ^ outputsCreated[2];
+	endRecipe += !outputsCreated[2];
 	outputsLeft[endRecipe] = 3;
-	endRecipe += 1 ^ outputsCreated[3];
+	endRecipe += !outputsCreated[3];
 	outputsLeft[endRecipe] = 4;
-	endRecipe += 1 ^ outputsCreated[4];
+	endRecipe += !outputsCreated[4];
 	outputsLeft[endRecipe] = 5;
-	endRecipe += 1 ^ outputsCreated[5];
+	endRecipe += !outputsCreated[5];
 	outputsLeft[endRecipe] = 6;
-	endRecipe += 1 ^ outputsCreated[6];
+	endRecipe += !outputsCreated[6];
 	outputsLeft[endRecipe] = 7;
-	endRecipe += 1 ^ outputsCreated[7];
+	endRecipe += !outputsCreated[7];
 	outputsLeft[endRecipe] = 8;
-	endRecipe += 1 ^ outputsCreated[8];
+	endRecipe += !outputsCreated[8];
 	outputsLeft[endRecipe] = 9;
-	endRecipe += 1 ^ outputsCreated[9];
+	endRecipe += !outputsCreated[9];
 	outputsLeft[endRecipe] = 10;
-	endRecipe += 1 ^ outputsCreated[10];
+	endRecipe += !outputsCreated[10];
 	outputsLeft[endRecipe] = 11;
-	endRecipe += 1 ^ outputsCreated[11];
+	endRecipe += !outputsCreated[11];
 	outputsLeft[endRecipe] = 12;
-	endRecipe += 1 ^ outputsCreated[12];
+	endRecipe += !outputsCreated[12];
 	outputsLeft[endRecipe] = 13;
-	endRecipe += 1 ^ outputsCreated[13];
+	endRecipe += !outputsCreated[13];
 	outputsLeft[endRecipe] = 14;
-	endRecipe += 1 ^ outputsCreated[14];
+	endRecipe += !outputsCreated[14];
 	outputsLeft[endRecipe] = 15;
-	endRecipe += 1 ^ outputsCreated[15];
+	endRecipe += !outputsCreated[15];
 	outputsLeft[endRecipe] = 16;
-	endRecipe += 1 ^ outputsCreated[16];
+	endRecipe += !outputsCreated[16];
 	outputsLeft[endRecipe] = 17;
-	endRecipe += 1 ^ outputsCreated[17];
+	endRecipe += !outputsCreated[17];
 	outputsLeft[endRecipe] = 18;
-	endRecipe += 1 ^ outputsCreated[18];
+	endRecipe += !outputsCreated[18];
 	outputsLeft[endRecipe] = 19;
-	endRecipe += 1 ^ outputsCreated[19];
+	endRecipe += !outputsCreated[19];
 	outputsLeft[endRecipe] = 20;
-	endRecipe += 1 ^ outputsCreated[20];
+	endRecipe += !outputsCreated[20];
 	outputsLeft[endRecipe] = 21;
-	endRecipe += 1 ^ outputsCreated[21];
+	endRecipe += !outputsCreated[21];
 	outputsLeft[endRecipe] = 22;
-	endRecipe += 1 ^ outputsCreated[22];
+	endRecipe += !outputsCreated[22];
 	outputsLeft[endRecipe] = 23;
-	endRecipe += 1 ^ outputsCreated[23];
+	endRecipe += !outputsCreated[23];
 	outputsLeft[endRecipe] = 24;
-	endRecipe += 1 ^ outputsCreated[24];
+	endRecipe += !outputsCreated[24];
 	outputsLeft[endRecipe] = 25;
-	endRecipe += 1 ^ outputsCreated[25];
+	endRecipe += !outputsCreated[25];
 	outputsLeft[endRecipe] = 26;
-	endRecipe += 1 ^ outputsCreated[26];
+	endRecipe += !outputsCreated[26];
 	outputsLeft[endRecipe] = 27;
-	endRecipe += 1 ^ outputsCreated[27];
+	endRecipe += !outputsCreated[27];
 	outputsLeft[endRecipe] = 28;
-	endRecipe += 1 ^ outputsCreated[28];
+	endRecipe += !outputsCreated[28];
 	outputsLeft[endRecipe] = 29;
-	endRecipe += 1 ^ outputsCreated[29];
+	endRecipe += !outputsCreated[29];
 	outputsLeft[endRecipe] = 30;
-	endRecipe += 1 ^ outputsCreated[30];
+	endRecipe += !outputsCreated[30];
 	outputsLeft[endRecipe] = 31;
-	endRecipe += 1 ^ outputsCreated[31];
+	endRecipe += !outputsCreated[31];
 	outputsLeft[endRecipe] = 32;
-	endRecipe += 1 ^ outputsCreated[32];
+	endRecipe += !outputsCreated[32];
 	outputsLeft[endRecipe] = 33;
-	endRecipe += 1 ^ outputsCreated[33];
+	endRecipe += !outputsCreated[33];
 	outputsLeft[endRecipe] = 34;
-	endRecipe += 1 ^ outputsCreated[34];
+	endRecipe += !outputsCreated[34];
 	outputsLeft[endRecipe] = 35;
-	endRecipe += 1 ^ outputsCreated[35];
+	endRecipe += !outputsCreated[35];
 	outputsLeft[endRecipe] = 36;
-	endRecipe += 1 ^ outputsCreated[36];
+	endRecipe += !outputsCreated[36];
 	outputsLeft[endRecipe] = 37;
-	endRecipe += 1 ^ outputsCreated[37];
+	endRecipe += !outputsCreated[37];
 	outputsLeft[endRecipe] = 38;
-	endRecipe += 1 ^ outputsCreated[38];
+	endRecipe += !outputsCreated[38];
 	outputsLeft[endRecipe] = 39;
-	endRecipe += 1 ^ outputsCreated[39];
+	endRecipe += !outputsCreated[39];
 	outputsLeft[endRecipe] = 40;
-	endRecipe += 1 ^ outputsCreated[40];
+	endRecipe += !outputsCreated[40];
 	outputsLeft[endRecipe] = 41;
-	endRecipe += 1 ^ outputsCreated[41];
+	endRecipe += !outputsCreated[41];
 	outputsLeft[endRecipe] = 42;
-	endRecipe += 1 ^ outputsCreated[42];
+	endRecipe += !outputsCreated[42];
 	outputsLeft[endRecipe] = 43;
-	endRecipe += 1 ^ outputsCreated[43];
+	endRecipe += !outputsCreated[43];
 	outputsLeft[endRecipe] = 44;
-	endRecipe += 1 ^ outputsCreated[44];
+	endRecipe += !outputsCreated[44];
 	outputsLeft[endRecipe] = 45;
-	endRecipe += 1 ^ outputsCreated[45];
+	endRecipe += !outputsCreated[45];
 	outputsLeft[endRecipe] = 46;
-	endRecipe += 1 ^ outputsCreated[46];
+	endRecipe += !outputsCreated[46];
 	outputsLeft[endRecipe] = 47;
-	endRecipe += 1 ^ outputsCreated[47];
+	endRecipe += !outputsCreated[47];
 	outputsLeft[endRecipe] = 48;
-	endRecipe += 1 ^ outputsCreated[48];
+	endRecipe += !outputsCreated[48];
 	outputsLeft[endRecipe] = 49;
-	endRecipe += 1 ^ outputsCreated[49];
+	endRecipe += !outputsCreated[49];
 	outputsLeft[endRecipe] = 50;
-	endRecipe += 1 ^ outputsCreated[50];
+	endRecipe += !outputsCreated[50];
 	outputsLeft[endRecipe] = 51;
-	endRecipe += 1 ^ outputsCreated[51];
+	endRecipe += !outputsCreated[51];
 	outputsLeft[endRecipe] = 52;
-	endRecipe += 1 ^ outputsCreated[52];
+	endRecipe += !outputsCreated[52];
 	outputsLeft[endRecipe] = 53;
-	endRecipe += 1 ^ outputsCreated[53];
+	endRecipe += !outputsCreated[53];
 	outputsLeft[endRecipe] = 54;
-	endRecipe += 1 ^ outputsCreated[54];
+	endRecipe += !outputsCreated[54];
 	outputsLeft[endRecipe] = 55;
-	endRecipe += 1 ^ outputsCreated[55];
+	endRecipe += !outputsCreated[55];
 	outputsLeft[endRecipe] = 56;
-	endRecipe += 1 ^ outputsCreated[56];
+	endRecipe += !outputsCreated[56];
 	outputsLeft[endRecipe] = 57;
-	endRecipe += 1 ^ outputsCreated[57];
+	endRecipe += !outputsCreated[57];
 
 	// Iterate through all output items that haven't been created
 	for (int currentRecipe = startRecipe; currentRecipe < endRecipe; currentRecipe++) {

--- a/recipes.c
+++ b/recipes.c
@@ -3,6 +3,7 @@
 #include "recipes.h"
 #include <string.h>
 #include "inventory.h"
+#include "absl/base/port.h"
 
 #define NUM_RECIPES 58 // Including Dried Bouquet trade
 #define NUM_ITEMS 107 // All listed items
@@ -30,7 +31,7 @@ struct ItemCombination parseCombo(int itemCount, enum Type_Sort item1, enum Type
  * Hard-coded array which tracks all recipes, the number of combinations
  * for each recipe, and the items that make up each of those combos.
  -------------------------------------------------------------------*/
-struct Recipe* getRecipeList() {
+ABSL_MUST_USE_RESULT struct Recipe* getRecipeList() {
 	struct Recipe* recipes = malloc(sizeof(struct Recipe) * NUM_RECIPES);
 
 	// Begin hard-coding recipes

--- a/recipes.h
+++ b/recipes.h
@@ -1,6 +1,13 @@
 #ifndef RECIPES_H
 #define RECIPES_H
 
-void copyDependentRecipes(int *newDependentRecipes, int *dependentRecipes);
+#include <stdbool.h>
+
+// These model Paper Mario TTYD game behavior. Do not edit these.
+#define NUM_RECIPES 58      // Including Chapter 5 representation and Dried Bouquet trade
+
+typedef bool outputCreatedArray_t[NUM_RECIPES];
+
+void copyDependentRecipes(int *newDependentRecipes, const int *dependentRecipes);
 
 #endif


### PR DESCRIPTION
Fix a big source of malloc churn, the `outputCreated` array in `struct BranchPath`

Whenever set, these arrays are allocated to the same size, so there is no point not just inline the whole array into the struct.

Depends on #34

With this, this can be passed along to subfunctions without copying, saving a _lot_ of malloc churn.

This also involved tightening up const correctness, so we can be assured we are not modifying the
original array when we didn't mean to, which is presumably why the original arrays were being
copied so much. Copying contents of outputCreated arrays is now done via a `memcpy` into the
target struct directly.

Also converts it to a `bool` array, so we can be assured it is 1 or 0 exactly and thus
be able to add them to an index without worrying about non-0 values.

Though a local array variable in the body of the function will allocate space for the whole array in the stack on the function's call, an array _parameter_ will not. Array parameters are passed by reference. So there isn't stack usage added by making the parameter type an array. Good ol' C consistency there. :laughing: 