### PR TITLE
Build and host Docker image in GitHub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
+# Strange fix for double star exclusions: https://github.com/moby/moby/issues/30018#issuecomment-875710305
+**/*.*
 !Makefile
-!*.c
-!*.h
+!**/*.c
+!**/*.h
 !config.txt
 !entrypoint.sh

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,45 @@
+name: MultiArchDockerBuild
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_multi_arch_image:
+    name: Build multi-arch Docker image.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
+

--- a/README.md
+++ b/README.md
@@ -65,9 +65,15 @@ Below are a set of config parameters which can be changed by the user. These wil
 - **Username**: This name will be submitted to the server to specify who found the roadmap. If you would like to be known for finding the fastest roadmap, change this name to a username of your choice. This is limited by 19 characters. A Discord bot in the TTYD speedrunning server will alert us with this Username when a new fastest roadmap is found.
 
 ## Docker Setup
-If your system is set up with Docker, you can quickly run CipesAtHome with a Docker image:
+If your system is set up with Docker, you can quickly run CipesAtHome with a Docker image.
+1. The following architectures are available:
+   - linux/amd64
+   - linux/386
+   - linux/arm64
+   - linux/arm/v7
+   - linux/arm/v6
 1. Mount the `/config` directory, set any environment variables, and run the container:
-   - `docker run -e USERNAME=MyName -v /my/volume/location/cipesathome:/config sevenchords/cipesathome`
+   - `docker run -e USERNAME=MyName -v /my/volume/location/cipesathome:/config ghcr.io/sevenchords/cipesathome`
 1. On first run, a config.txt will automatically be created. Feel free to modify it, as it will be used on the next startup.
    - If you're having issues with the config file, check its filesystem permissions and make sure it ends with a newline
 


### PR DESCRIPTION
- Adds GitHub Action to build and push a multi-architecture Docker image to the GitHub container registry ([example](https://github.com/claabs/CipesAtHome/pkgs/container/cipesathome))
- Updates the docs for the new image URL
- Adds the dockerignore suggestion I made [here](https://github.com/SevenChords/CipesAtHome/pull/36#discussion_r749395071)

Maybe in the future, we could also use GitHub actions to build and release a binary on each change to master.