### PR TITLE
Rewrite linker flag for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ifeq ($(UNAME), Darwin)
 	MACPREFIX:=$(shell brew --prefix)
 	CC:=$(MACPREFIX)/opt/llvm/bin/clang
 	CFLAGS:=-I$(MACPREFIX)/include -L$(MACPREFIX)/lib $(CFLAGS)
+	FINAL_TARGET_CFLAGS:=$(subst --gc-sections,-dead_strip,$(FINAL_TARGET_CFLAGS))
 endif
 
 default: $(TARGET)


### PR DESCRIPTION
Use subst to strictly replace `--gc-sections` with the `ld64` equivalent option `-dead_strip` in `FINAL_TARGET_CFLAGS` when `uname` is `Darwin`

Fixes #42
