### PR TITLE
Fix crash related to curl usage

### DIFF
--- a/FTPManagement.c
+++ b/FTPManagement.c
@@ -148,7 +148,6 @@ void handle_post(char* url, FILE *fp, int localRecord, char *nickname) {
 
 		curl_easy_cleanup(curl);
 	}
-	curl_global_cleanup();
 	free(wt.data);
 
 	// Log the body of the return of the POST request


### PR DESCRIPTION
curl_global_cleanup should only be called once you're done using curl. In a single-threaded context, this would technically be fine (but inefficient), since the next curl_easy_init would call curl_global_init. But if other threads might currently be using curl, it's definitely not and can lead to crashes or other corruption.