### PR TITLE
Fix build error

### DIFF
--- a/config.c
+++ b/config.c
@@ -88,7 +88,7 @@ void validateSetting(const char *path, enum SettingType type, int *errorCount) {
 		long long llValue;
 		double floatValue;
 		int boolValue;
-		char *stringValue;
+		const char *stringValue;
 	case intSetting:
 		ret = config_lookup_int(config, path, &intValue);
 		break;


### PR DESCRIPTION
GCC noticed a discrepancy between the type of `stringValue` and the type of the third parameter of `config_lookup_string`. (There is, unfortunately, no way to get this even as a warning in MSVC.)